### PR TITLE
Add resize background image support

### DIFF
--- a/SlackowWall/Features/Keybinds/Enums/KeyAction.swift
+++ b/SlackowWall/Features/Keybinds/Enums/KeyAction.swift
@@ -15,6 +15,7 @@ enum KeyAction {
     case resetAll
     case lock
     case toggleSensitivityScaling
+    case toggleResizeBackground
 
     static func from(event: NSEvent) -> KeyAction? {
         let profile = Settings[\.keybinds]
@@ -25,6 +26,9 @@ enum KeyAction {
         if profile.lockKey.matches(event: event) { return .lock }
         if profile.resetGKey.matches(event: event) { return .resetGlobal }
         if profile.sensitivityScalingGKey.matches(event: event) { return .toggleSensitivityScaling }
+        if profile.resizeBackgroundToggleGKey.matches(event: event) {
+            return .toggleResizeBackground
+        }
         return nil
     }
 }

--- a/SlackowWall/Features/Keybinds/ViewModels/ShortcutManager.swift
+++ b/SlackowWall/Features/Keybinds/ViewModels/ShortcutManager.swift
@@ -157,23 +157,33 @@ class ShortcutManager: ObservableObject, Manager {
         guard case (.some(let w), let h, let x, let y) = Settings[\.self].wideDimensions else {
             return
         }
-        resize(pid: pid, x: x, y: y, width: w, height: h)
+        resize(pid: pid, x: x, y: y, width: w, height: h, resizeBackgroundAction: .show)
     }
 
     @discardableResult func resizeBase(pid: pid_t? = nil) -> ResizeResult {
         guard let pid = pid ?? activeInstancePID(),
             case (.some(let w), .some(let h), .some(let x), .some(let y)) = Settings[\.self]
                 .baseDimensions
-        else { return ResizeResult(type: .noResize) }
-        return resize(pid: pid, x: x, y: y, width: w, height: h, force: true)
+        else {
+            ResizeBackgroundManager.shared.hide()
+            return ResizeResult(type: .noResize)
+        }
+        return resize(
+            pid: pid, x: x, y: y, width: w, height: h, force: true,
+            resizeBackgroundAction: .hide)
     }
 
     func resizeReset(pid: pid_t) {
         guard
             case (.some(let w), .some(let h), .some(let x), .some(let y)) = Settings[\.self]
                 .resetDimensions
-        else { return }
-        resize(pid: pid, x: x, y: y, width: w, height: h, force: true)
+        else {
+            ResizeBackgroundManager.shared.hide()
+            return
+        }
+        resize(
+            pid: pid, x: x, y: y, width: w, height: h, force: true,
+            resizeBackgroundAction: .hide)
     }
 
     func resizeThin() {
@@ -181,7 +191,9 @@ class ShortcutManager: ObservableObject, Manager {
             case (let w, .some(let h), let x, let y) = Settings[\.self].thinDimensions,
             let instance = TrackingManager.shared.trackedInstances.first(where: { $0.pid == pid })
         else { return }
-        let result = resize(pid: pid, x: x, y: y, width: w, height: h, dontClosePie: true)
+        let result = resize(
+            pid: pid, x: x, y: y, width: w, height: h, dontClosePie: true,
+            resizeBackgroundAction: .show)
         if result.type == .resizedToOriginal && Settings[\.utility].pieProjectorEnabled {
             Task(priority: .userInitiated) {
                 _ = await result.task?.result
@@ -202,7 +214,9 @@ class ShortcutManager: ObservableObject, Manager {
         guard let pid = activeInstancePID() else { return }
         let (w, h, x, y) = Settings[\.self].tallDimensions(
             for: TrackingManager.shared.trackedInstances.first { $0.pid == pid })
-        let result = resize(pid: pid, x: x, y: y, width: w, height: h, dontClosePie: !changeSens)
+        let result = resize(
+            pid: pid, x: x, y: y, width: w, height: h, dontClosePie: !changeSens,
+            resizeBackgroundAction: .show)
         if result.type == .resizedToOriginal,
             let instance = TrackingManager.shared.trackedInstances.first(where: { $0.pid == pid })
         {
@@ -236,7 +250,8 @@ class ShortcutManager: ObservableObject, Manager {
     // True means resized to dimension, False means resized but not to your dimension, nil means did not resize.
     @discardableResult func resize(
         pid: pid_t, x: CGFloat? = nil, y: CGFloat? = nil, width: CGFloat, height: CGFloat,
-        force: Bool = false, dontClosePie: Bool = false
+        force: Bool = false, dontClosePie: Bool = false,
+        resizeBackgroundAction: ResizeBackgroundAction = .unchanged
     ) -> ResizeResult {
         let pids = TrackingManager.shared.getValues(\.pid)
         let instance = TrackingManager.shared.trackedInstances.first(where: { $0.pid == pid })
@@ -310,10 +325,22 @@ class ShortcutManager: ObservableObject, Manager {
                     pid: pid, x: newPosition.x, y: newPosition.y, width: newSize.width,
                     height: newSize.height)
             }
+            switch resizeBackgroundAction {
+                case .show:
+                    ResizeBackgroundManager.shared.show(behind: instance)
+                case .hide:
+                    ResizeBackgroundManager.shared.hide()
+                case .unchanged:
+                    break
+            }
             LogManager.shared.appendLog("Finished Resizing Instance: \(pid), \(newSize)")
             return ResizeResult(type: .resizedToOriginal, task: task)
         }
         return ResizeResult(type: .noResize)
+    }
+
+    enum ResizeBackgroundAction {
+        case show, hide, unchanged
     }
 
     struct ResizeResult {

--- a/SlackowWall/Features/Keybinds/ViewModels/ShortcutManager.swift
+++ b/SlackowWall/Features/Keybinds/ViewModels/ShortcutManager.swift
@@ -63,6 +63,8 @@ class ShortcutManager: ObservableObject, Manager {
             resizeTall(changeSens: false)
         } else if type == .keyDown && settings.sensitivityScalingGKey.matches(event: key) {
             Settings[\.utility].sensitivityScaleEnabled.toggle()
+        } else if type == .keyDown && settings.resizeBackgroundToggleGKey.matches(event: key) {
+            toggleResizeBackground()
         } else {
             return
         }
@@ -152,6 +154,22 @@ class ShortcutManager: ObservableObject, Manager {
         }
     }
 
+    func toggleResizeBackground() {
+        if ResizeBackgroundManager.shared.isVisible {
+            ResizeBackgroundManager.shared.hide()
+            return
+        }
+
+        let activeInstance = activeInstancePID().flatMap { pid in
+            TrackingManager.shared.trackedInstances.first { $0.pid == pid }
+        }
+        guard let instance = activeInstance ?? TrackingManager.shared.trackedInstances.first else {
+            return
+        }
+
+        ResizeBackgroundManager.shared.show(behind: instance)
+    }
+
     func resizeWide() {
         guard let pid = activeInstancePID() else { return }
         guard case (.some(let w), let h, let x, let y) = Settings[\.self].wideDimensions else {
@@ -165,7 +183,7 @@ class ShortcutManager: ObservableObject, Manager {
             case (.some(let w), .some(let h), .some(let x), .some(let y)) = Settings[\.self]
                 .baseDimensions
         else {
-            ResizeBackgroundManager.shared.hide()
+            ResizeBackgroundManager.shared.hideAutomatically()
             return ResizeResult(type: .noResize)
         }
         return resize(
@@ -178,7 +196,7 @@ class ShortcutManager: ObservableObject, Manager {
             case (.some(let w), .some(let h), .some(let x), .some(let y)) = Settings[\.self]
                 .resetDimensions
         else {
-            ResizeBackgroundManager.shared.hide()
+            ResizeBackgroundManager.shared.hideAutomatically()
             return
         }
         resize(
@@ -300,6 +318,7 @@ class ShortcutManager: ObservableObject, Manager {
                 })
             else {
                 LogManager.shared.appendLog("Instance with pid: \(pid) not found")
+                ResizeBackgroundManager.shared.hideIfTargetRemoved(pid: pid)
                 return ResizeResult(type: .noResize)
             }
             if !force && Settings[\.mode].blockResizeInGUI && instance.hasMod(.stateOutput) {
@@ -327,9 +346,9 @@ class ShortcutManager: ObservableObject, Manager {
             }
             switch resizeBackgroundAction {
                 case .show:
-                    ResizeBackgroundManager.shared.show(behind: instance)
+                    ResizeBackgroundManager.shared.showAutomatically(behind: instance)
                 case .hide:
-                    ResizeBackgroundManager.shared.hide()
+                    ResizeBackgroundManager.shared.hideAutomatically()
                 case .unchanged:
                     break
             }

--- a/SlackowWall/Features/ResizeBackground/ResizeBackgroundManager.swift
+++ b/SlackowWall/Features/ResizeBackground/ResizeBackgroundManager.swift
@@ -1,0 +1,110 @@
+//
+//  ResizeBackgroundManager.swift
+//  SlackowWall
+//
+//  Created by Codex on 6/1/26.
+//
+
+import AppKit
+import SwiftUI
+
+final class ResizeBackgroundManager: ObservableObject {
+    static let shared = ResizeBackgroundManager()
+
+    @Published private(set) var image: NSImage?
+
+    private var window: NSPanel?
+
+    private init() {}
+
+    func show(behind instance: TrackedInstance) {
+        let windowID = instance.windowID
+
+        DispatchQueue.main.async {
+            self.show(windowID: windowID)
+        }
+    }
+
+    func hide() {
+        DispatchQueue.main.async {
+            self.hideImmediately()
+        }
+    }
+
+    private func show(windowID: CGWindowID?) {
+        let settings = Settings[\.mode]
+        guard settings.resizeBackgroundEnabled else {
+            hideImmediately()
+            return
+        }
+        guard let imageURL = settings.resizeBackgroundImage else {
+            hideImmediately()
+            return
+        }
+        guard let image = NSImage(contentsOf: imageURL) else {
+            LogManager.shared.appendLog(
+                "Failed to load resize background image:",
+                imageURL.path(percentEncoded: false)
+            )
+            hideImmediately()
+            return
+        }
+        guard let windowID else {
+            LogManager.shared.appendLog("Could not show resize background: missing window ID")
+            hideImmediately()
+            return
+        }
+
+        self.image = image
+
+        let backgroundWindow = makeWindow()
+        if let screen = NSScreen.primary {
+            backgroundWindow.setFrame(screen.frame, display: true)
+        }
+
+        backgroundWindow.orderFrontRegardless()
+        backgroundWindow.order(.below, relativeTo: Int(windowID))
+    }
+
+    private func hideImmediately() {
+        window?.orderOut(nil)
+        image = nil
+    }
+
+    private func makeWindow() -> NSPanel {
+        if let window {
+            return window
+        }
+
+        let window = ResizeBackgroundWindow(
+            contentRect: NSScreen.primary?.frame ?? .zero,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier(SWWindowID.resizeBackground.rawValue)
+        window.contentView = NSHostingView(rootView: ResizeBackgroundView())
+        window.backgroundColor = .black
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        window.canHide = false
+        window.hidesOnDeactivate = false
+        window.collectionBehavior = [
+            .canJoinAllSpaces,
+            .fullScreenAuxiliary,
+            .ignoresCycle,
+            .stationary,
+        ]
+        // Keep the image below normal Minecraft windows even if relative ordering fails.
+        window.level = NSWindow.Level(rawValue: NSWindow.Level.normal.rawValue - 1)
+
+        self.window = window
+        return window
+    }
+}
+
+private final class ResizeBackgroundWindow: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}

--- a/SlackowWall/Features/ResizeBackground/ResizeBackgroundManager.swift
+++ b/SlackowWall/Features/ResizeBackground/ResizeBackgroundManager.swift
@@ -12,16 +12,29 @@ final class ResizeBackgroundManager: ObservableObject {
     static let shared = ResizeBackgroundManager()
 
     @Published private(set) var image: NSImage?
+    @Published private(set) var isVisible = false
 
     private var window: NSPanel?
+    private var targetPID: pid_t?
 
     private init() {}
 
     func show(behind instance: TrackedInstance) {
+        let pid = instance.pid
         let windowID = instance.windowID
 
         DispatchQueue.main.async {
-            self.show(windowID: windowID)
+            self.show(pid: pid, windowID: windowID)
+        }
+    }
+
+    func showAutomatically(behind instance: TrackedInstance) {
+        let pid = instance.pid
+        let windowID = instance.windowID
+
+        DispatchQueue.main.async {
+            guard Settings[\.mode].resizeBackgroundAutoAppearance else { return }
+            self.show(pid: pid, windowID: windowID)
         }
     }
 
@@ -31,7 +44,28 @@ final class ResizeBackgroundManager: ObservableObject {
         }
     }
 
-    private func show(windowID: CGWindowID?) {
+    func hideAutomatically() {
+        DispatchQueue.main.async {
+            guard Settings[\.mode].resizeBackgroundAutoAppearance else { return }
+            self.hideImmediately()
+        }
+    }
+
+    func hideIfTargetRemoved(pid: pid_t) {
+        DispatchQueue.main.async {
+            guard self.targetPID == pid else { return }
+            self.hideImmediately()
+        }
+    }
+
+    func hideIfTargetRemoved(_ removedPIDs: Set<pid_t>) {
+        DispatchQueue.main.async {
+            guard let targetPID = self.targetPID, removedPIDs.contains(targetPID) else { return }
+            self.hideImmediately()
+        }
+    }
+
+    private func show(pid: pid_t, windowID: CGWindowID?) {
         let settings = Settings[\.mode]
         guard settings.resizeBackgroundEnabled else {
             hideImmediately()
@@ -55,6 +89,14 @@ final class ResizeBackgroundManager: ObservableObject {
             return
         }
 
+        let onScreenWindows = orderedOnScreenWindows()
+        guard onScreenWindows.contains(where: { self.windowID(from: $0) == windowID }) else {
+            LogManager.shared.appendLog("Could not show resize background: Minecraft window is gone")
+            hideImmediately()
+            return
+        }
+
+        targetPID = pid
         self.image = image
 
         let backgroundWindow = makeWindow()
@@ -63,12 +105,15 @@ final class ResizeBackgroundManager: ObservableObject {
         }
 
         backgroundWindow.orderFrontRegardless()
-        backgroundWindow.order(.below, relativeTo: Int(windowID))
+        orderBackgroundWindow(backgroundWindow, belowExceptionsFor: windowID, in: onScreenWindows)
+        isVisible = true
     }
 
     private func hideImmediately() {
         window?.orderOut(nil)
         image = nil
+        isVisible = false
+        targetPID = nil
     }
 
     private func makeWindow() -> NSPanel {
@@ -96,11 +141,97 @@ final class ResizeBackgroundManager: ObservableObject {
             .ignoresCycle,
             .stationary,
         ]
-        // Keep the image below normal Minecraft windows even if relative ordering fails.
-        window.level = NSWindow.Level(rawValue: NSWindow.Level.normal.rawValue - 1)
+        window.level = .normal
 
         self.window = window
         return window
+    }
+
+    private func orderBackgroundWindow(
+        _ backgroundWindow: NSWindow,
+        belowExceptionsFor targetWindowID: CGWindowID,
+        in onScreenWindows: [[String: Any]]
+    ) {
+        let exceptionWindowIDs = exceptionWindowIDs(
+            targetWindowID: targetWindowID,
+            in: onScreenWindows)
+
+        for windowInfo in onScreenWindows {
+            guard
+                let windowID = windowID(from: windowInfo),
+                exceptionWindowIDs.contains(windowID)
+            else {
+                continue
+            }
+
+            backgroundWindow.order(.below, relativeTo: Int(windowID))
+        }
+    }
+
+    private func exceptionWindowIDs(
+        targetWindowID: CGWindowID,
+        in onScreenWindows: [[String: Any]]
+    ) -> Set<CGWindowID> {
+        var windowIDs: Set<CGWindowID> = [targetWindowID]
+
+        if let eyeProjectorWindow = NSApp.getWindow(.eyeProjector), eyeProjectorWindow.isVisible {
+            windowIDs.insert(CGWindowID(eyeProjectorWindow.windowNumber))
+        }
+
+        if let pieProjectorWindow = NSApp.getWindow(.pieProjector), pieProjectorWindow.isVisible {
+            windowIDs.insert(CGWindowID(pieProjectorWindow.windowNumber))
+        }
+
+        let ninjabrainPIDs = TrackingManager.shared.ninjabrainBotPIDs()
+        for windowInfo in onScreenWindows where isNinjabrainBotWindow(windowInfo, pids: ninjabrainPIDs) {
+            if let windowID = windowID(from: windowInfo) {
+                windowIDs.insert(windowID)
+            }
+        }
+
+        return windowIDs
+    }
+
+    private func orderedOnScreenWindows() -> [[String: Any]] {
+        guard
+            let windows = CGWindowListCopyWindowInfo(
+                [.optionOnScreenOnly, .excludeDesktopElements],
+                kCGNullWindowID) as? [[String: Any]]
+        else {
+            return []
+        }
+
+        return windows
+    }
+
+    private func isNinjabrainBotWindow(_ windowInfo: [String: Any], pids: Set<pid_t>) -> Bool {
+        if let pid = pid(from: windowInfo), pids.contains(pid) {
+            return true
+        }
+
+        guard let ownerName = windowInfo[kCGWindowOwnerName as String] as? String else {
+            return false
+        }
+
+        return ownerName.localizedCaseInsensitiveContains("Ninjabrain")
+    }
+
+    private func windowID(from windowInfo: [String: Any]) -> CGWindowID? {
+        guard let value = windowInfo[kCGWindowNumber as String] else { return nil }
+
+        if let number = value as? NSNumber {
+            return CGWindowID(truncating: number)
+        }
+
+        return value as? CGWindowID
+    }
+
+    private func pid(from windowInfo: [String: Any]) -> pid_t? {
+        guard let number = windowInfo[kCGWindowOwnerPID as String] as? NSNumber else {
+            return nil
+        }
+
+        return pid_t(number.int32Value)
     }
 }
 

--- a/SlackowWall/Features/ResizeBackground/ResizeBackgroundView.swift
+++ b/SlackowWall/Features/ResizeBackground/ResizeBackgroundView.swift
@@ -1,0 +1,30 @@
+//
+//  ResizeBackgroundView.swift
+//  SlackowWall
+//
+//  Created by Codex on 6/1/26.
+//
+
+import SwiftUI
+
+struct ResizeBackgroundView: View {
+    @ObservedObject private var manager = ResizeBackgroundManager.shared
+
+    @AppSettings(\.mode)
+    private var settings
+
+    var body: some View {
+        ZStack {
+            Color.black
+
+            if let image = manager.image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .opacity(settings.resizeBackgroundOpacity)
+            }
+        }
+        .clipped()
+        .ignoresSafeArea()
+    }
+}

--- a/SlackowWall/Features/Settings/Models/Sections/KeybindSection.swift
+++ b/SlackowWall/Features/Settings/Models/Sections/KeybindSection.swift
@@ -17,6 +17,7 @@ extension Preferences {
         var planarGKey: Keybinding = .none
         var baseGKey: Keybinding = .none
         var sensitivityScalingGKey: Keybinding = .none
+        var resizeBackgroundToggleGKey: Keybinding = .none
         var tallNoSensGKey: Keybinding = .none
 
         var resetAllKey: Keybinding = .init(.t)

--- a/SlackowWall/Features/Settings/Models/Sections/ModeSection.swift
+++ b/SlackowWall/Features/Settings/Models/Sections/ModeSection.swift
@@ -29,6 +29,10 @@ extension Preferences {
 
         var blockResizeInGUI: Bool = true
 
+        var resizeBackgroundEnabled: Bool = false
+        var resizeBackgroundImage: URL? = nil
+        var resizeBackgroundOpacity: Double = 1.0
+
         init() {}
     }
     struct SizeMode: Codable, Hashable {

--- a/SlackowWall/Features/Settings/Models/Sections/ModeSection.swift
+++ b/SlackowWall/Features/Settings/Models/Sections/ModeSection.swift
@@ -30,6 +30,7 @@ extension Preferences {
         var blockResizeInGUI: Bool = true
 
         var resizeBackgroundEnabled: Bool = false
+        var resizeBackgroundAutoAppearance: Bool = true
         var resizeBackgroundImage: URL? = nil
         var resizeBackgroundOpacity: Double = 1.0
 

--- a/SlackowWall/Features/Settings/Views/Pages/Keybindings/KeybindingsSettings.swift
+++ b/SlackowWall/Features/Settings/Views/Pages/Keybindings/KeybindingsSettings.swift
@@ -79,6 +79,17 @@ struct KeybindingsSettings: View {
 
                         KeybindingView(keybinding: \.sensitivityScalingGKey)
                     }
+
+                    Divider()
+
+                    HStack {
+                        SettingsLabel(
+                            title: "Toggle Resize Background",
+                            description: "Show or hide the selected resize background.",
+                            font: .body)
+
+                        KeybindingView(keybinding: \.resizeBackgroundToggleGKey)
+                    }
                 }
             }
 

--- a/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeCardView.swift
+++ b/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeCardView.swift
@@ -15,6 +15,7 @@ struct ModeCardView: View {
     var isGameplayMode: Bool = false
     @State var isExpanded: Bool = false
     var keybind: Binding<Keybinding>?
+    var resizeBackgroundAction: ShortcutManager.ResizeBackgroundAction = .unchanged
 
     var posHints: (String, String) = ("--", "--")
     @Binding var mode: Preferences.SizeMode
@@ -167,7 +168,8 @@ struct ModeCardView: View {
         guard case (.some(let w), .some(let h), let x, let y) = actualDimensions else { return }
         trackingManager.trackedInstances.forEach { inst in
             ShortcutManager.shared.resize(
-                pid: inst.pid, x: x, y: y, width: w, height: h, force: true)
+                pid: inst.pid, x: x, y: y, width: w, height: h, force: true,
+                resizeBackgroundAction: resizeBackgroundAction)
         }
     }
 

--- a/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeSettings.swift
+++ b/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeSettings.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ModeSettings: View {
     @StateObject private var viewModel = ModeSettingsViewModel()
+    @State private var showingResizeBackgroundFileImporter = false
 
     @AppSettings(\.mode) private var settings
     @AppSettings(\.keybinds) private var keybinds
@@ -59,6 +60,7 @@ struct ModeSettings: View {
                     "The size of the game while you are in an instance, required for other modes to work.\nOptional Keybind goes directly to gameplay, other keybinds toggle their sizes.",
                 actualDimensions: Settings[\.self].baseDimensions,
                 isGameplayMode: true, isExpanded: true, keybind: $keybinds.baseGKey,
+                resizeBackgroundAction: .hide,
                 posHints: ("", ""),
                 mode: $settings.baseMode
             )
@@ -69,6 +71,7 @@ struct ModeSettings: View {
                 actualDimensions: Settings[\.self].tallDimensions(
                     for: TrackingManager.shared.trackedInstances.first),
                 keybind: $keybinds.tallGKey,
+                resizeBackgroundAction: .show,
                 mode: $settings.tallMode
             )
 
@@ -78,6 +81,7 @@ struct ModeSettings: View {
                     "Thin is generally used for buried treasures, preemptive, and/or e-ray.",
                 actualDimensions: Settings[\.self].thinDimensions,
                 keybind: $keybinds.thinGKey,
+                resizeBackgroundAction: .show,
                 mode: $settings.thinMode
             )
 
@@ -86,6 +90,7 @@ struct ModeSettings: View {
                 description: "Wide is generally used for seeing further with planar fog.",
                 actualDimensions: Settings[\.self].wideDimensions,
                 keybind: $keybinds.planarGKey,
+                resizeBackgroundAction: .show,
                 mode: $settings.wideMode
             )
 
@@ -94,6 +99,7 @@ struct ModeSettings: View {
                 description:
                     "Reset is used for wall mode, and is used to make your instances wider so you can see more on the preview.",
                 actualDimensions: Settings[\.self].resetDimensions,
+                resizeBackgroundAction: .hide,
                 posHints: ("", ""),
                 mode: $settings.resetMode
             )
@@ -103,6 +109,81 @@ struct ModeSettings: View {
             )
             SettingsCardView {
                 VStack {
+                    SettingsToggleView(
+                        title: "Resize Background",
+                        description:
+                            "Shows a selected image behind Minecraft while Tall, Thin, or Wide mode is active.",
+                        option: $settings.resizeBackgroundEnabled
+                    )
+                    .onChange(of: settings.resizeBackgroundEnabled) { isEnabled in
+                        if !isEnabled {
+                            ResizeBackgroundManager.shared.hide()
+                        }
+                    }
+
+                    Divider()
+
+                    HStack {
+                        SettingsLabel(
+                            title: "Background Image",
+                            description: settings.resizeBackgroundImage?.lastPathComponent
+                                ?? "No image selected.",
+                            font: .body)
+
+                        if let image = resizeBackgroundPreviewImage {
+                            Image(nsImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 42, height: 42)
+                                .clipShape(RoundedRectangle(cornerRadius: 5))
+                        }
+
+                        if settings.resizeBackgroundImage != nil {
+                            Button {
+                                settings.resizeBackgroundImage = nil
+                                ResizeBackgroundManager.shared.hide()
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .symbolRenderingMode(.hierarchical)
+                                    .resizable()
+                                    .frame(width: 18, height: 18)
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        Button(settings.resizeBackgroundImage == nil ? "Select Image" : "Change") {
+                            showingResizeBackgroundFileImporter = true
+                        }
+                    }
+                    .disabled(!settings.resizeBackgroundEnabled)
+                    .fileImporter(
+                        isPresented: $showingResizeBackgroundFileImporter,
+                        allowedContentTypes: [.image],
+                        allowsMultipleSelection: false
+                    ) { result in
+                        switch result {
+                            case .success(let urls):
+                                settings.resizeBackgroundImage = urls.first
+                                ResizeBackgroundManager.shared.hide()
+                            case .failure(let error):
+                                LogManager.shared.appendLog(
+                                    "Failed to select resize background image",
+                                    error.localizedDescription)
+                        }
+                    }
+
+                    Divider()
+
+                    HStack {
+                        SettingsLabel(title: "Background Opacity", font: .body)
+                        Text("\(Int(settings.resizeBackgroundOpacity * 100))%")
+                        Slider(value: $settings.resizeBackgroundOpacity, in: 0...1)
+                            .frame(width: 200, height: 25)
+                    }
+                    .disabled(!settings.resizeBackgroundEnabled)
+
+                    Divider()
+
                     HStack {
                         SettingsLabel(
                             title: "Toggle Tall Mode (No Modifiers)",
@@ -125,6 +206,10 @@ struct ModeSettings: View {
             .smooth.delay(viewModel.multipleOutOfBounds ? 0 : 0.3),
             value: viewModel.multipleOutOfBounds
         )
+    }
+
+    private var resizeBackgroundPreviewImage: NSImage? {
+        settings.resizeBackgroundImage.flatMap { NSImage(contentsOf: $0) }
     }
 }
 

--- a/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeSettings.swift
+++ b/SlackowWall/Features/Settings/Views/Pages/Modes/Views/ModeSettings.swift
@@ -123,6 +123,21 @@ struct ModeSettings: View {
 
                     Divider()
 
+                    SettingsToggleView(
+                        title: "Auto-Background Appearance",
+                        description:
+                            "Automatically shows the background in Tall, Thin, and Wide modes, then hides it in Gameplay or Reset.",
+                        option: $settings.resizeBackgroundAutoAppearance
+                    )
+                    .disabled(!settings.resizeBackgroundEnabled)
+                    .onChange(of: settings.resizeBackgroundAutoAppearance) { isEnabled in
+                        if !isEnabled {
+                            ResizeBackgroundManager.shared.hide()
+                        }
+                    }
+
+                    Divider()
+
                     HStack {
                         SettingsLabel(
                             title: "Background Image",

--- a/SlackowWall/Features/Tracking/ViewModels/InstanceManager.swift
+++ b/SlackowWall/Features/Tracking/ViewModels/InstanceManager.swift
@@ -99,6 +99,8 @@ import SwiftUI
                     ShortcutManager.shared.globalReset()
                 case .toggleSensitivityScaling:
                     break
+                case .toggleResizeBackground:
+                    ShortcutManager.shared.toggleResizeBackground()
                 case .none:
                     return
             }

--- a/SlackowWall/Features/Tracking/ViewModels/TrackingManager.swift
+++ b/SlackowWall/Features/Tracking/ViewModels/TrackingManager.swift
@@ -41,6 +41,7 @@ class TrackingManager: ObservableObject {
         let currentPIDs = Set(currentApps.map(\.processIdentifier))
 
         // Update existing instances and remove those no longer running
+        var removedPIDs = Set<pid_t>()
         trackedInstances.removeAll { trackedInstance in
             if currentPIDs.contains(trackedInstance.pid) {
                 // Update existing tracked instance
@@ -49,8 +50,12 @@ class TrackingManager: ObservableObject {
             } else {
                 // Remove instance that no longer exists
                 LogManager.shared.appendLog("Removing instance \(trackedInstance.pid)")
+                removedPIDs.insert(trackedInstance.pid)
                 return true
             }
+        }
+        if !removedPIDs.isEmpty {
+            ResizeBackgroundManager.shared.hideIfTargetRemoved(removedPIDs)
         }
 
         // Add new instances
@@ -136,6 +141,10 @@ class TrackingManager: ObservableObject {
         return ninBot
     }
 
+    func ninjabrainBotPIDs() -> Set<pid_t> {
+        Set(getAllApps().filter(isNinjabrainBot).map(\.processIdentifier))
+    }
+
     private func getAllApps() -> [NSRunningApplication] {
         return NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
     }
@@ -211,6 +220,7 @@ class TrackingManager: ObservableObject {
 
             if !removedPIDs.isEmpty {
                 LogManager.shared.appendLog("Minecraft instances closed: \(removedPIDs)")
+                ResizeBackgroundManager.shared.hideIfTargetRemoved(removedPIDs)
             }
 
             // Update the tracked instances

--- a/SlackowWall/Utils/Extensions/NSApplication+Ext.swift
+++ b/SlackowWall/Utils/Extensions/NSApplication+Ext.swift
@@ -44,6 +44,7 @@ extension NSApplication {
 enum SWWindowID: String {
     case eyeProjector = "eye-projector-window"
     case pieProjector = "pie-projector-window"
+    case resizeBackground = "resize-background-window"
     case settings = "settings-window"
     case slackowwall = "slackowwall-window"
 }


### PR DESCRIPTION
## Summary
This is an addition to SlackowWall, adding a background image on resize, a similar and better alternative to OBS's background display, but this one is more dynamic and customizable.

- Add an optional resize background image for Tall, Thin, and Wide modes
- Add settings to enable the background, choose an image, clear it, and adjust opacity
- Show the background behind Minecraft while resize modes are active
- Hide the background when returning to Gameplay/Base/Reset or disabling the setting
- Sits above all other windows besides Minecraft, Pie Projector, Eye Projector, and NinjaBrainBot

## Testing
- `git diff --check`
- `xcodebuild -project SlackowWall.xcodeproj -scheme SlackowWall -configuration Release -derivedDataPath /private/tmp/SlackowWallBuild -skipMacroValidation CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project SlackowWall.xcodeproj -scheme SlackowWall -configuration Debug -derivedDataPath /private/tmp/SlackowWallTestBuild -skipMacroValidation CODE_SIGNING_ALLOWED=NO test`
- Manually verified in `SlackowWall-dev.app` that the selected image appears behind Minecraft in Tall/Thin/Wide modes and hides in Gameplay/Base/Reset

## Customization

- Auto-Background Appearance is a dynamic way that your background will appear only when resized, and does not stay static like OBS
- There is also a keybind option for toggling the background manually

I have tested this in-game and can confirm it works!